### PR TITLE
Rds configurationoptions support

### DIFF
--- a/src/typeorm-aurora-data-api-driver.ts
+++ b/src/typeorm-aurora-data-api-driver.ts
@@ -12,19 +12,20 @@ export default class DataApiDriver {
     private readonly resourceArn: string,
     private readonly database: string,
     private readonly loggerFn: (query: string, parameters?: any[]) => void = () => undefined,
+    private readonly serviceConfigOptions?: ConfigurationOptions,
   ) {
     this.region = region
     this.secretArn = secretArn
     this.resourceArn = resourceArn
     this.database = database
     this.loggerFn = loggerFn
+    this.serviceConfigOptions = serviceConfigOptions || {}
+    this.serviceConfigOptions.region = region
     this.client = createDataApiClient({
       secretArn,
       resourceArn,
       database,
-      options: {
-        region,
-      },
+      options: serviceConfigOptions,
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,9 +436,9 @@ acorn-walk@^6.0.1:
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
 acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.0.1:
   version "6.3.0"


### PR DESCRIPTION
Pull request that solves #8: 
Support for argument 'serviceConfigOptions' (AWS.ConfigurationOptions) 

The change also requires an update in TypeORM. That part is already implemented but no pull request made yet. Needs to wait till this changed is merged into typeorm-aurora-data-api-driver. 

Once merged I'll create a pull request in TypeORM for the changes in [this](https://github.com/cklam2/typeorm/commit/00984c6326c37a9754b77d81ad3dd0dca62874eb) branch.