### PR TITLE
Support continueAfterTimeout for long running quires 

### DIFF
--- a/src/typeorm-aurora-data-api-driver.ts
+++ b/src/typeorm-aurora-data-api-driver.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
 import createDataApiClient from 'data-api-client'
-import {ColumnMetadata} from 'typeorm/metadata/ColumnMetadata'
+import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
 import {
   MysqlQueryTransformer,
   PostgresQueryTransformer,
-  QueryTransformer
+  QueryTransformer,
 } from './query-transformer'
 
 class DataApiDriver {
@@ -48,7 +48,7 @@ class DataApiDriver {
       sql: transformedQueryData.queryString,
       parameters: transformedQueryData.parameters,
       transactionId: this.transactionId,
-      continueAfterTimeout: continueAfterTimeout
+      continueAfterTimeout,
 
     })
 
@@ -64,24 +64,24 @@ class DataApiDriver {
   }
 
   public async startTransaction(): Promise<void> {
-    const {transactionId} = await this.client.beginTransaction()
+    const { transactionId } = await this.client.beginTransaction()
     this.transactionId = transactionId
   }
 
   public async commitTransaction(): Promise<void> {
-    await this.client.commitTransaction({transactionId: this.transactionId})
+    await this.client.commitTransaction({ transactionId: this.transactionId })
     this.transactionId = undefined
   }
 
   public async rollbackTransaction(): Promise<void> {
-    await this.client.rollbackTransaction({transactionId: this.transactionId})
+    await this.client.rollbackTransaction({ transactionId: this.transactionId })
     this.transactionId = undefined
   }
 }
 
 const createMysqlDriver = (region: string, secretArn: string, resourceArn: string, database: string,
-                           loggerFn: (query: string, parameters?: any[]) => void = () => undefined,
-                           serviceConfigOptions?: any, formatOptions?: any) => new DataApiDriver(
+  loggerFn: (query: string, parameters?: any[]) => void = () => undefined,
+  serviceConfigOptions?: any, formatOptions?: any) => new DataApiDriver(
   region,
   secretArn,
   resourceArn,
@@ -95,8 +95,8 @@ const createMysqlDriver = (region: string, secretArn: string, resourceArn: strin
 export default createMysqlDriver
 
 const createPostgresDriver = (region: string, secretArn: string, resourceArn: string, database: string,
-                              loggerFn: (query: string, parameters?: any[]) => void = () => undefined,
-                              serviceConfigOptions?: any, formatOptions?: any) => new DataApiDriver(
+  loggerFn: (query: string, parameters?: any[]) => void = () => undefined,
+  serviceConfigOptions?: any, formatOptions?: any) => new DataApiDriver(
   region,
   secretArn,
   resourceArn,


### PR DESCRIPTION
closes https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/82
expose param for `continueAfterTimeout` on a query level 