### PR TITLE
fix(mysql): Error when saving entities with enum fields (#109)

### DIFF
--- a/src/query-transformer/mysql-query-transformer.ts
+++ b/src/query-transformer/mysql-query-transformer.ts
@@ -52,7 +52,6 @@ export class MysqlQueryTransformer extends QueryTransformer {
       case 'simple-enum':
         return {
           value: '' + value,
-          cast: metadata.enumName || `${metadata.entityMetadata.tableName}_${metadata.databaseName.toLowerCase()}_enum`,
         }
       default:
         return {


### PR DESCRIPTION
Remove the cast property from the MySQL query transformer, since Aurora Data API does not like it.

Fixes #109