### PR TITLE
Support scale and precision in numeric casting

### DIFF
--- a/src/query-transformer/mysql-query-transformer.ts
+++ b/src/query-transformer/mysql-query-transformer.ts
@@ -3,6 +3,7 @@ import {
   dateToDateString,
   dateToDateTimeString,
   dateToTimeString,
+  getDecimalCast,
   simpleArrayToString,
   stringToSimpleArray,
 } from '../utils/transform.utils'
@@ -36,7 +37,7 @@ export class MysqlQueryTransformer extends QueryTransformer {
       case 'numeric':
         return {
           value: '' + value,
-          cast: 'DECIMAL',
+          cast: getDecimalCast(metadata),
         }
       case 'set':
       case 'simple-array':

--- a/src/query-transformer/postgres-query-transformer.ts
+++ b/src/query-transformer/postgres-query-transformer.ts
@@ -1,5 +1,5 @@
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
-import { dateToDateString, dateToTimeString, dateToDateTimeString, simpleArrayToString, stringToSimpleArray } from '../utils/transform.utils'
+import { dateToDateString, dateToTimeString, dateToDateTimeString, simpleArrayToString, stringToSimpleArray, getDecimalCast } from '../utils/transform.utils'
 import { QueryTransformer } from './query-transformer'
 
 export class PostgresQueryTransformer extends QueryTransformer {
@@ -46,7 +46,7 @@ export class PostgresQueryTransformer extends QueryTransformer {
       case 'numeric':
         return {
           value: '' + value,
-          cast: 'DECIMAL',
+          cast: getDecimalCast(metadata),
         }
       case 'simple-array':
         return {

--- a/src/utils/transform.utils.ts
+++ b/src/utils/transform.utils.ts
@@ -1,3 +1,5 @@
+import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
+
 const pad = (val: string | number, num = 2) => '0'.repeat(num - (val.toString()).length) + val
 
 export const dateToDateTimeString = (date: Date) => {
@@ -61,4 +63,13 @@ export const stringToSimpleArray = (value: string|any): any[] => {
   }
 
   return value
+}
+
+
+export const getDecimalCast = ({ precision, scale }: Pick<ColumnMetadata, 'scale' | 'precision'>): string => {
+  if (!precision) return 'DECIMAL'
+
+  if (!scale) return `DECIMAL(${precision})`
+
+  return `DECIMAL(${precision},${scale})`
 }


### PR DESCRIPTION
Hello and thanks for this awesome project !

I have noticed a small bug when using `DECIMAL` data types : the cast operation removed any floating-point digit.

I think the cause was the cast to `DECIMAL` (without precision), so I added this support.

Hope this helps !