### PR TITLE
fix: strictly compare parameter value to undefined

### DIFF
--- a/src/query-transformer/mysql-query-transformer.ts
+++ b/src/query-transformer/mysql-query-transformer.ts
@@ -151,7 +151,7 @@ export class MysqlQueryTransformer extends QueryTransformer {
         return parameter
       }
 
-      if (typeof parameter === 'object' && parameter?.value) {
+      if (typeof parameter === 'object' && parameter?.value !== undefined) {
         return ({
           name: `param_${index}`,
           ...parameter,

--- a/src/query-transformer/postgres-query-transformer.ts
+++ b/src/query-transformer/postgres-query-transformer.ts
@@ -168,7 +168,7 @@ export class PostgresQueryTransformer extends QueryTransformer {
         return parameter
       }
 
-      if (typeof parameter === 'object' && parameter?.value) {
+      if (typeof parameter === 'object' && parameter?.value !== undefined) {
         return ({
           name: `param_${index + 1}`,
           ...parameter,


### PR DESCRIPTION
fix https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/83

At least it fixes the usage of empty sets:
```ts
  @Column({ type: 'set', enum: enumValues(NetworkType)})
  networkType: NetworkType[];
```
An empty array `[]` is transformed in empty string `''` by typeorm.
The parameter is `{ value: '' }` which fails this condition https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/blob/c01d226382ff700f7986f75ae3078ef6aa7ce92a/src/query-transformer/mysql-query-transformer.ts#L154

The resulting parameter is 
```ts
{
 name: "param_1",
 value: {
   value: '',
 },
}
```
which breaks later because it is invalid
```
console.error                                                                                                                                                                                                    
    Error: 'param_1' is an invalid type                                                                                                                                                                            
        at error (node_modules/typeorm-aurora-data-api-driver/node_modules/data-api-client/index.js:39:35)                                                                      
        at formatType (node_modules/typeorm-aurora-data-api-driver/node_modules/data-api-client/index.js:215:4)                                                                 
        at formatParam (node_modules/typeorm-aurora-data-api-driver/dist/typeorm-aurora-data-api-driver.umd.js:481:48)                                                          
        at node_modules/typeorm-aurora-data-api-driver/node_modules/data-api-client/index.js:136:20     