### PR TITLE
fix: Enable to use enums in a different than default DB schema in PostgreSQL

### DIFF
--- a/docker/initdb/pginit.sql
+++ b/docker/initdb/pginit.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA "foo";

--- a/docker/pg.yml
+++ b/docker/pg.yml
@@ -20,6 +20,8 @@ services:
     restart: always
     environment:
       POSTGRES_PASSWORD: example
-      POSTGRES_DB: test
+      POSTGRES_DB: postgres
     ports:
       - "5432:5432"
+    volumes:
+      - ./initdb:/docker-entrypoint-initdb.d/

--- a/src/query-transformer/postgres-query-transformer.ts
+++ b/src/query-transformer/postgres-query-transformer.ts
@@ -68,7 +68,7 @@ export class PostgresQueryTransformer extends QueryTransformer {
       case 'enum':
         return {
           value: '' + value,
-          cast: metadata.enumName || `${metadata.entityMetadata.tableName}_${metadata.databaseName.toLowerCase()}_enum`,
+          cast: metadata.enumName || `${metadata.entityMetadata.schema ? `${metadata.entityMetadata.schema}.` : ''}${metadata.entityMetadata.tableName}_${metadata.databaseName.toLowerCase()}_enum`,
         }
       default:
         return {

--- a/test/functional/pg/basic/entity/SpecificSchemaSimpleEnumEntity.ts
+++ b/test/functional/pg/basic/entity/SpecificSchemaSimpleEnumEntity.ts
@@ -1,0 +1,92 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm'
+
+export enum NumericEnum {
+  ADMIN,
+  EDITOR,
+  MODERATOR,
+  GHOST
+}
+
+export enum StringEnum {
+  ADMIN = 'a',
+  EDITOR = 'e',
+  MODERATOR = 'm',
+  GHOST = 'g'
+}
+
+export enum StringNumericEnum {
+  ONE = '1',
+  TWO = '2',
+  THREE = '3',
+  FOUR = '4'
+}
+
+export enum HeterogeneousEnum {
+  NO = 0,
+  YES = 'YES',
+}
+
+export type ArrayDefinedStringEnumType = 'admin' | 'editor' | 'ghost'
+
+export type ArrayDefinedNumericEnumType = 11 | 12 | 13
+
+@Entity({ schema: 'foo' })
+export class SpecificSchemaSimpleEnumEntity {
+  @PrimaryColumn()
+  public id!: number
+
+  @Column({
+    type: 'enum',
+    enum: NumericEnum,
+    default: NumericEnum.MODERATOR,
+  })
+  public numericEnum!: NumericEnum
+
+  @Column({
+    type: 'simple-enum',
+    enum: NumericEnum,
+    default: NumericEnum.MODERATOR,
+  })
+  public numericSimpleEnum!: NumericEnum
+
+  @Column({
+    type: 'simple-enum',
+    enum: StringEnum,
+    default: StringEnum.GHOST,
+  })
+  public stringEnum!: StringEnum
+
+  @Column({
+    type: 'simple-enum',
+    enum: StringNumericEnum,
+    default: StringNumericEnum.FOUR,
+  })
+  public stringNumericEnum!: StringNumericEnum
+
+  @Column({
+    type: 'simple-enum',
+    enum: HeterogeneousEnum,
+    default: HeterogeneousEnum.NO,
+  })
+  public heterogeneousEnum!: HeterogeneousEnum
+
+  @Column({
+    type: 'simple-enum',
+    enum: ['admin', 'editor', 'ghost'],
+    default: 'ghost',
+  })
+  public arrayDefinedStringEnum!: ArrayDefinedStringEnumType
+
+  @Column({
+    type: 'simple-enum',
+    enum: [11, 12, 13],
+    default: 12,
+  })
+  public arrayDefinedNumericEnum!: ArrayDefinedNumericEnumType
+
+  @Column({
+    type: 'simple-enum',
+    enum: StringEnum,
+  })
+  public enumWithoutdefault!: StringEnum
+}

--- a/test/functional/pg/basic/simple-queries.pg-func.test.ts
+++ b/test/functional/pg/basic/simple-queries.pg-func.test.ts
@@ -5,6 +5,7 @@ import { Category } from './entity/Category'
 import { DateEntity } from './entity/DateEntity'
 import { JsonEntity } from './entity/JsonEntity'
 import { SimpleArrayEntity } from './entity/SimpleArrayEntity'
+import { SpecificSchemaSimpleEnumEntity } from './entity/SpecificSchemaSimpleEnumEntity'
 import { Post } from './entity/Post'
 import {
   HeterogeneousEnum,
@@ -161,6 +162,33 @@ describe('aurora data api pg > simple queries', () => {
       const enumEntityRepository = connection.getRepository(SimpleEnumEntity)
 
       const enumEntity = new SimpleEnumEntity()
+      enumEntity.id = 1
+      enumEntity.numericEnum = NumericEnum.EDITOR
+      enumEntity.numericSimpleEnum = NumericEnum.EDITOR
+      enumEntity.stringEnum = StringEnum.ADMIN
+      enumEntity.stringNumericEnum = StringNumericEnum.TWO
+      enumEntity.heterogeneousEnum = HeterogeneousEnum.YES
+      enumEntity.arrayDefinedStringEnum = 'editor'
+      enumEntity.arrayDefinedNumericEnum = 13
+      enumEntity.enumWithoutdefault = StringEnum.ADMIN
+      await enumEntityRepository.save(enumEntity)
+
+      const loadedEnumEntity = await enumEntityRepository.findOneBy({ id: 1 })
+      expect(loadedEnumEntity!.numericEnum).toBe(NumericEnum.EDITOR)
+      expect(loadedEnumEntity!.numericSimpleEnum).toBe(NumericEnum.EDITOR)
+      expect(loadedEnumEntity!.stringEnum).toBe(StringEnum.ADMIN)
+      expect(loadedEnumEntity!.stringNumericEnum).toBe(StringNumericEnum.TWO)
+      expect(loadedEnumEntity!.heterogeneousEnum).toBe(HeterogeneousEnum.YES)
+      expect(loadedEnumEntity!.arrayDefinedStringEnum).toBe('editor')
+      expect(loadedEnumEntity!.arrayDefinedNumericEnum).toBe(13)
+    })
+  })
+
+  it('should correctly save and retrieve enums in different db schema', async () => {
+    await useCleanDatabase('postgres', { entities: [UuidPost, Category, SpecificSchemaSimpleEnumEntity] }, async (connection) => {
+      const enumEntityRepository = connection.getRepository(SpecificSchemaSimpleEnumEntity)
+
+      const enumEntity = new SpecificSchemaSimpleEnumEntity()
       enumEntity.id = 1
       enumEntity.numericEnum = NumericEnum.EDITOR
       enumEntity.numericSimpleEnum = NumericEnum.EDITOR


### PR DESCRIPTION
There was an issue when we used enums with PostgreSQL and we used other than default DB schema at the same time. 
In that case the `cast` property of the SQL parameter was wrong because it pointed to non-existent enum - it was not prefixed with the schema name and so the cast parameter is invalid from PostgreSQL point of view and then it failed.

So the fix is about prefixing enum name with database schema in case the entity is decorated with custom schema.

I created a test for this scenario. I wrote it first and then it failed. After the fix it became green.

I also found out, that there was a mistake in `pg.yml`. The tests ran on top of `postgres` database and not `test` database so I made it clear by not creating `test` database at all because it was always ignored anyway.