### PR TITLE
fix: Serialize queries executed within a transaction.

### DIFF
--- a/test/typeorm-aurora-data-api-driver.unit.test.ts
+++ b/test/typeorm-aurora-data-api-driver.unit.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable import/first */
 jest.mock('../src/data-api-client', () => {
   const query = jest.fn(async () => ({ result: '' }))
+  const beginTransaction = jest.fn(async () => ({ transactionId: '1' }))
   return {
     createDataApiClient: () => ({
       query,
+      beginTransaction,
     }),
   }
 })
@@ -20,6 +22,11 @@ describe('DataApiDriver', () => {
     const mockLoggerFn = jest.fn()
 
     describe('query', () => {
+      beforeEach(() => {
+        // Clear mock calls
+        jest.clearAllMocks()
+      })
+
       it('should apply the queryConfigOptions continueAfterTimeout if it exists', async () => {
         const testDriver = driver(mockRegion, mockSecretArn, mockResourceArn, mockDatabase, mockLoggerFn, { queryConfigOptions: { continueAfterTimeout: true } })
 
@@ -34,6 +41,42 @@ describe('DataApiDriver', () => {
         await testDriver.query('select 1')
 
         expect(createDataApiClient().query).toHaveBeenCalledWith(expect.objectContaining({ continueAfterTimeout: false }))
+      })
+
+      it('should execute queries in a transaction sequentially', async () => {
+        const testDriver = driver(mockRegion, mockSecretArn, mockResourceArn, mockDatabase, mockLoggerFn)
+
+        const delayedQuery = () => {
+          let onStarted = () => {}
+          const hasStarted = new Promise((resolve) => {
+            onStarted = () => resolve(undefined)
+          })
+          let done = () => {}
+          const isDone = new Promise((resolve) => {
+            done = () => resolve({ result: '' })
+          })
+          jest.mocked(createDataApiClient().query).mockImplementationOnce(() => {
+            onStarted()
+            return isDone
+          })
+          return [hasStarted, done] as const
+        }
+        const [query1Started, resolveQuery1] = delayedQuery()
+
+        await testDriver.startTransaction()
+
+        const query1 = testDriver.query('select 1')
+        const query2 = testDriver.query('select 2')
+
+        await query1Started
+        expect(createDataApiClient().query).toHaveBeenCalledWith(expect.objectContaining({ sql: 'select 1' }))
+        expect(createDataApiClient().query).not.toHaveBeenCalledWith(expect.objectContaining({ sql: 'select 2' }))
+
+        resolveQuery1()
+        await query1
+        await query2
+
+        expect(createDataApiClient().query).toHaveBeenCalledWith(expect.objectContaining({ sql: 'select 2' }))
       })
     })
   })


### PR DESCRIPTION
Aurora Serverless v2 Data API does not support concurrent queries against a transaction, raising the error "Transaction is still running a query".

TypeORM however, when persisting an entity with multiple changed related entities, will issue queries to the driver in parallel as part of a transaction. Additionally, when run as part of an explicit transaction, the initial SELECT queries to check the existing database records may also be issued in parallel.
See [here](https://github.com/typeorm/typeorm/blob/master/src/persistence/SubjectExecutor.ts#L669) for the parallel execution of UPDATEs.

Traditional (connection based) database drivers would serialize these queries by virtue of sending them over the same connection. To safely use the Data API here without disabling transactions (and loosing atomicity) or quite hacky workarounds to get TypeORM to only update on entity at a time, the driver needs to serialize the queries issued within a transaction.

Note: The `data-api-client` contains a section relating to "Transaction Management", however these functions are unused in the `DataApiDriver`, or anywhere else within this repository. The API is rather curious, seemingly requiring all queries to be submitted as functions before starting the actual transaction and it is unclear to me if this could fit into the TypeORM driver API.